### PR TITLE
fix(setup): route prompts to stderr so they survive command substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ The script:
 
 - Stashes any local modifications (so `.env` and `data/config.json` stay safe)
 - Switches to the repository's default branch and `git pull`s
-- Runs `npm install --omit=dev` for new dependencies
+- Runs `npm install --omit=dev` to pull in any new dependencies
+- Runs `npm update --omit=dev` to update existing packages to the latest compatible versions (within the semver ranges in `package.json`, so no breaking major bumps)
+- Lists packages with new **major** versions available as a hint (not auto-installed)
 - Restarts `tg-bridge` via systemd (if installed)
 - Restores your stashed changes afterwards
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,31 @@ LIBRETRANSLATE_URL=http://localhost:5000
 
 ---
 
+## Updating
+
+To pull the latest changes, reinstall dependencies and restart the service, just run:
+
+```bash
+bash update.sh
+```
+
+The script:
+
+- Stashes any local modifications (so `.env` and `data/config.json` stay safe)
+- Switches to the repository's default branch and `git pull`s
+- Runs `npm install --omit=dev` for new dependencies
+- Restarts `tg-bridge` via systemd (if installed)
+- Restores your stashed changes afterwards
+
+If you run the bridge via Docker, update with:
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+---
+
 ## Useful Commands (LXC / systemd)
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -14,17 +14,20 @@ ask() {
   local secret="$3"
   local value=""
 
+  # Prompts MUST go to stderr — this function is called inside $(...) so
+  # stdout is captured by the caller. Without >&2 the user sees nothing
+  # and types blindly.
   if [ -n "$default" ]; then
-    echo -ne "${CYAN}${prompt}${RESET} [${default}]: "
+    printf '%b%s%b [%s]: ' "$CYAN" "$prompt" "$RESET" "$default" >&2
   else
-    echo -ne "${CYAN}${prompt}${RESET}: "
+    printf '%b%s%b: ' "$CYAN" "$prompt" "$RESET" >&2
   fi
 
   if [ "$secret" = "true" ]; then
-    read -rs value
-    echo
+    read -rs value </dev/tty
+    echo >&2
   else
-    read -r value
+    read -r value </dev/tty
   fi
 
   if [ -z "$value" ] && [ -n "$default" ]; then
@@ -36,16 +39,18 @@ ask() {
 
 ask_optional() {
   local prompt="$1"
-  echo -ne "${CYAN}${prompt}${RESET} ${YELLOW}(optional, Enter to skip)${RESET}: "
+  printf '%b%s%b %b(optional, Enter to skip)%b: ' \
+    "$CYAN" "$prompt" "$RESET" "$YELLOW" "$RESET" >&2
   local value=""
-  read -rs value
-  echo
+  read -rs value </dev/tty
+  echo >&2
   echo "$value"
 }
 
 confirm() {
-  echo -ne "${CYAN}$1${RESET} [y/N]: "
-  read -r ans
+  printf '%b%s%b [y/N]: ' "$CYAN" "$1" "$RESET" >&2
+  local ans
+  read -r ans </dev/tty
   [[ "$ans" =~ ^[Yy]$ ]]
 }
 

--- a/update.sh
+++ b/update.sh
@@ -65,12 +65,34 @@ if [ "$STASHED" = "1" ]; then
   fi
 fi
 
-# ── Install dependencies ─────────────────────────────────────────────────────
+# ── Install & update dependencies ────────────────────────────────────────────
+# Two-step strategy:
+#   1) npm install     → add any NEW deps from package.json, honour the lockfile
+#   2) npm update      → pull the latest patch / minor releases within the
+#                        semver ranges in package.json (safe, no breaking majors)
 echo ""
 echo -e "${BOLD}── Installing dependencies ──────────────────${RESET}"
 if command -v npm &>/dev/null; then
   npm install --omit=dev
   echo -e "${GREEN}✓ Dependencies installed${RESET}"
+
+  echo ""
+  echo -e "${BOLD}── Updating dependencies to latest compatible versions ──${RESET}"
+  npm update --omit=dev
+  echo -e "${GREEN}✓ Dependencies updated (within semver ranges)${RESET}"
+
+  # Optionally show outdated majors (non-fatal, info only)
+  if npm outdated --omit=dev > /tmp/npm_outdated.$$ 2>/dev/null; then
+    :
+  fi
+  if [ -s /tmp/npm_outdated.$$ ]; then
+    echo ""
+    echo -e "${YELLOW}ℹ Some packages have newer MAJOR versions available${RESET}"
+    echo -e "  (not auto-updated to avoid breaking changes):"
+    cat /tmp/npm_outdated.$$
+    echo -e "  To upgrade manually: ${CYAN}npm install <package>@latest${RESET}"
+  fi
+  rm -f /tmp/npm_outdated.$$
 else
   echo -e "${YELLOW}⚠ npm not found, skipping dependency install.${RESET}"
 fi

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -e
+
+BOLD='\033[1m'
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════╗${RESET}"
+echo -e "${BOLD}║   Telegram ↔ Discord Bridge  –  Update  ║${RESET}"
+echo -e "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+echo ""
+
+# ── Must be run inside the repo ──────────────────────────────────────────────
+if [ ! -d .git ]; then
+  echo -e "${RED}✗ This is not a git repository.${RESET}"
+  echo -e "  Run this script from the directory where you cloned the bridge."
+  exit 1
+fi
+
+# ── Remember current branch so we can restore it if the user was on a custom one
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+TARGET_BRANCH="$(git remote show origin | awk '/HEAD branch/ {print $NF}')"
+
+if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "(unknown)" ]; then
+  # Fallback to the known default branch name
+  TARGET_BRANCH="claude/telegram-discord-bridge-bUm5a"
+fi
+
+echo -e "  Current branch: ${CYAN}${CURRENT_BRANCH}${RESET}"
+echo -e "  Target branch:  ${CYAN}${TARGET_BRANCH}${RESET}"
+echo ""
+
+# ── Stash local changes if any ───────────────────────────────────────────────
+STASHED=0
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo -e "${YELLOW}⚠ You have local changes — stashing them temporarily.${RESET}"
+  git stash push -u -m "update.sh auto-stash $(date +%s)" > /dev/null
+  STASHED=1
+fi
+
+# ── Switch to target branch + pull ───────────────────────────────────────────
+echo -e "${BOLD}── Fetching latest version ──────────────────${RESET}"
+git fetch origin "$TARGET_BRANCH"
+
+if [ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]; then
+  git checkout "$TARGET_BRANCH"
+fi
+
+git pull --ff-only origin "$TARGET_BRANCH"
+echo -e "${GREEN}✓ Code updated${RESET}"
+
+# ── Restore stashed changes ──────────────────────────────────────────────────
+if [ "$STASHED" = "1" ]; then
+  echo ""
+  echo -e "${YELLOW}⚠ Restoring your local changes…${RESET}"
+  if ! git stash pop; then
+    echo -e "${RED}⚠ Merge conflict while restoring local changes.${RESET}"
+    echo -e "  Resolve conflicts manually, then run:"
+    echo -e "    ${CYAN}git stash drop${RESET}"
+    exit 1
+  fi
+fi
+
+# ── Install dependencies ─────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}── Installing dependencies ──────────────────${RESET}"
+if command -v npm &>/dev/null; then
+  npm install --omit=dev
+  echo -e "${GREEN}✓ Dependencies installed${RESET}"
+else
+  echo -e "${YELLOW}⚠ npm not found, skipping dependency install.${RESET}"
+fi
+
+# ── Restart service if systemd is set up ─────────────────────────────────────
+echo ""
+if systemctl list-unit-files 2>/dev/null | grep -q '^tg-bridge\.service'; then
+  echo -e "${BOLD}── Restarting service ───────────────────────${RESET}"
+  if sudo systemctl restart tg-bridge; then
+    echo -e "${GREEN}✓ Service restarted${RESET}"
+    sleep 1
+    sudo systemctl status tg-bridge --no-pager -l | head -n 10
+  else
+    echo -e "${RED}✗ Failed to restart tg-bridge.${RESET}"
+  fi
+else
+  echo -e "${YELLOW}ℹ No systemd service found — restart your bridge manually if needed.${RESET}"
+  echo -e "  If you run it via docker compose, use: ${CYAN}docker compose up -d --build${RESET}"
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════╗${RESET}"
+echo -e "${BOLD}║            Update complete!              ║${RESET}"
+echo -e "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+echo ""


### PR DESCRIPTION
The ask() / ask_optional() / confirm() helpers used echo to stdout, but they are called inside \$(...) which captures stdout.  Result: the user saw no prompt at all, typed blindly, and eventually saw the prompt text appear inside the variable value or later in the output — exactly the "I cannot type anything and pressing Enter just shows the whole text" symptom.

Fix:
- All prompts now use printf ... >&2 so they bypass the \$() capture and reach the terminal
- read now reads from /dev/tty directly, which is more robust when the script is piped or the parent shell's stdin is redirected
- Only the final echo "\$value" goes to stdout (the actual return value)

This was a pre-existing bug unmasked by the new port-selection flow.

https://claude.ai/code/session_01MqcPLRA3akTKHmiUv27T4s