### PR TITLE
Add translation fallback chain with exhaustion tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -491,6 +491,45 @@
     }
     .service-status-active   { color: var(--success); font-size: 0.8rem; font-weight: 600; }
     .service-status-inactive { color: var(--muted);   font-size: 0.8rem; font-weight: 600; }
+
+    /* ── TRANSLATION CHAIN ──────────────────────────────────────────── */
+    .chain-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; min-height: 24px; }
+    .chain-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 0.82rem;
+    }
+    .chain-item-label { flex: 1; }
+    .chain-badge {
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 7px;
+      border-radius: 4px;
+      flex-shrink: 0;
+    }
+    .chain-badge.ok     { background: rgba(87,242,135,.12); color: var(--success); }
+    .chain-badge.warn   { background: rgba(254,231,92,.1);  color: var(--warn); }
+    .chain-badge.danger { background: rgba(237,66,69,.12);  color: var(--danger); }
+    .chain-badge.muted  { background: var(--surface2);      color: var(--muted); }
+    .chain-controls { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+    .btn-chain {
+      background: var(--surface2);
+      color: var(--muted);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 3px 8px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    .btn-chain:hover { color: var(--text); border-color: var(--accent); opacity: 1; }
+    .btn-chain.danger:hover { color: var(--danger); border-color: var(--danger); }
+    .btn-chain:disabled { opacity: 0.3; cursor: not-allowed; }
   </style>
 </head>
 <body>
@@ -645,6 +684,21 @@
           <button type="submit" class="btn-primary">Save Settings</button>
         </div>
       </form>
+
+      <!-- Translation chain — uses /api/translation-chain, not the .env form -->
+      <hr style="border:none;border-top:1px solid var(--border);margin:24px 0 18px">
+      <div class="settings-section" id="chain-section">
+        <h3>Translation Fallback-Kette</h3>
+        <p class="settings-hint">Reihenfolge der Übersetzungs-Anbieter. Wenn ein Anbieter sein Limit erreicht oder ausfällt, wird der nächste in der Kette versucht. <em>Keine Übersetzung</em> stoppt die Kette ohne Übersetzung. Die Kette gilt global für alle Verbindungen und ist sofort wirksam.</p>
+        <div id="chain-list" class="chain-list">
+          <span style="font-size:0.8rem;color:var(--muted)">Lädt…</span>
+        </div>
+        <div class="chain-controls">
+          <select id="chain-add-select" style="font-size:0.8rem;padding:5px 8px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);outline:none;"></select>
+          <button type="button" class="btn-chain" onclick="addChainEntry()">+ Hinzufügen</button>
+          <button type="button" class="btn-chain danger" id="chain-reset-btn" style="margin-left:auto;display:none" onclick="resetAllExhausted()">Reset alle Erschöpften</button>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -1513,6 +1567,9 @@ async function loadSettings() {
     if (cfg['DEEPL_API_KEY']) loadDeepLUsage();
     else { const w = document.getElementById('deepl-usage'); if (w) w.style.display = 'none'; }
 
+    // Load translation fallback chain
+    loadTranslationChain();
+
   } catch (err) {
     showToast('Could not load settings: ' + err.message, 'error');
   }
@@ -1547,6 +1604,177 @@ document.getElementById('settings-form').addEventListener('submit', async (e) =>
     showToast('Save failed: ' + err.message, 'error');
   }
 });
+
+// ── Translation chain ─────────────────────────────────────────────────────────
+
+let _chainData = { chain: [], exhausted: [] };
+
+const CHAIN_PROVIDERS = [
+  ...PROVIDERS.map(p => ({ id: p.id, label: p.label })),
+  { id: 'none', label: '— Keine Übersetzung (Stopp)' }
+];
+
+async function loadTranslationChain() {
+  try {
+    const data = await api('GET', '/api/translation-chain');
+    _chainData = data;
+    renderChainList(data.chain, data.exhausted);
+    const sel = document.getElementById('chain-add-select');
+    if (sel && !sel.children.length) {
+      for (const p of CHAIN_PROVIDERS) {
+        const opt = document.createElement('option');
+        opt.value = p.id;
+        opt.textContent = p.label;
+        sel.appendChild(opt);
+      }
+    }
+    const resetBtn = document.getElementById('chain-reset-btn');
+    if (resetBtn) resetBtn.style.display = data.exhausted.length ? '' : 'none';
+  } catch (err) {
+    const list = document.getElementById('chain-list');
+    if (list) list.innerHTML = `<span style="font-size:0.8rem;color:var(--danger)">Fehler: ${err.message}</span>`;
+  }
+}
+
+function renderChainList(chain, exhausted) {
+  const list = document.getElementById('chain-list');
+  if (!list) return;
+  list.innerHTML = '';
+  const status = window._providerStatus ?? {};
+  const exhaustedSet = new Set(exhausted);
+
+  if (!chain.length) {
+    const empty = document.createElement('p');
+    empty.style.cssText = 'font-size:0.8rem;color:var(--muted);margin:0';
+    empty.textContent = 'Keine Fallback-Kette konfiguriert — es wird nur der primäre Anbieter jeder Verbindung genutzt.';
+    list.appendChild(empty);
+    return;
+  }
+
+  chain.forEach((provider, idx) => {
+    const item = document.createElement('div');
+    item.className = 'chain-item';
+
+    const num = document.createElement('span');
+    num.style.cssText = 'color:var(--muted);font-size:0.75rem;min-width:16px;flex-shrink:0';
+    num.textContent = `${idx + 1}.`;
+    item.appendChild(num);
+
+    const lbl = document.createElement('span');
+    lbl.className = 'chain-item-label';
+    const provInfo = CHAIN_PROVIDERS.find(p => p.id === provider);
+    lbl.textContent = provInfo ? provInfo.label : provider;
+    item.appendChild(lbl);
+
+    // Status badge
+    const badge = document.createElement('span');
+    badge.className = 'chain-badge';
+    if (provider === 'none') {
+      badge.classList.add('muted');
+      badge.textContent = 'Stopp';
+      item.appendChild(badge);
+    } else if (exhaustedSet.has(provider)) {
+      badge.classList.add('danger');
+      badge.textContent = 'Erschöpft';
+      item.appendChild(badge);
+      const resetOne = document.createElement('button');
+      resetOne.type = 'button';
+      resetOne.className = 'btn-chain';
+      resetOne.textContent = 'Reset';
+      resetOne.addEventListener('click', () => resetExhaustedProvider(provider));
+      item.appendChild(resetOne);
+    } else if (status[provider] === false) {
+      badge.classList.add('warn');
+      badge.textContent = 'Kein Key';
+      item.appendChild(badge);
+    } else {
+      badge.classList.add('ok');
+      badge.textContent = 'Bereit';
+      item.appendChild(badge);
+    }
+
+    // Reorder / remove buttons
+    const upBtn = document.createElement('button');
+    upBtn.type = 'button';
+    upBtn.className = 'btn-chain';
+    upBtn.textContent = '▲';
+    upBtn.title = 'Nach oben';
+    upBtn.disabled = idx === 0;
+    upBtn.addEventListener('click', () => {
+      const c = [..._chainData.chain];
+      [c[idx - 1], c[idx]] = [c[idx], c[idx - 1]];
+      saveChain(c);
+    });
+
+    const downBtn = document.createElement('button');
+    downBtn.type = 'button';
+    downBtn.className = 'btn-chain';
+    downBtn.textContent = '▼';
+    downBtn.title = 'Nach unten';
+    downBtn.disabled = idx === chain.length - 1;
+    downBtn.addEventListener('click', () => {
+      const c = [..._chainData.chain];
+      [c[idx], c[idx + 1]] = [c[idx + 1], c[idx]];
+      saveChain(c);
+    });
+
+    const rmBtn = document.createElement('button');
+    rmBtn.type = 'button';
+    rmBtn.className = 'btn-chain danger';
+    rmBtn.textContent = '✕';
+    rmBtn.title = 'Entfernen';
+    rmBtn.addEventListener('click', () => {
+      const c = _chainData.chain.filter((_, i) => i !== idx);
+      saveChain(c);
+    });
+
+    item.append(upBtn, downBtn, rmBtn);
+    list.appendChild(item);
+  });
+}
+
+async function addChainEntry() {
+  const sel = document.getElementById('chain-add-select');
+  if (!sel) return;
+  const newChain = [..._chainData.chain, sel.value];
+  await saveChain(newChain);
+}
+
+async function saveChain(chain) {
+  try {
+    const data = await api('POST', '/api/translation-chain', { chain });
+    _chainData = { ..._chainData, chain: data.chain };
+    renderChainList(_chainData.chain, _chainData.exhausted);
+  } catch (err) {
+    showToast(`Fehler: ${err.message}`, 'error');
+  }
+}
+
+async function resetAllExhausted() {
+  try {
+    await api('DELETE', '/api/translation-chain/exhausted');
+    _chainData = { ..._chainData, exhausted: [] };
+    renderChainList(_chainData.chain, _chainData.exhausted);
+    const resetBtn = document.getElementById('chain-reset-btn');
+    if (resetBtn) resetBtn.style.display = 'none';
+    showToast('Alle erschöpften Anbieter zurückgesetzt.', 'ok');
+  } catch (err) {
+    showToast(`Fehler: ${err.message}`, 'error');
+  }
+}
+
+async function resetExhaustedProvider(provider) {
+  try {
+    await api('DELETE', `/api/translation-chain/exhausted/${provider}`);
+    _chainData = { ..._chainData, exhausted: _chainData.exhausted.filter(p => p !== provider) };
+    renderChainList(_chainData.chain, _chainData.exhausted);
+    const resetBtn = document.getElementById('chain-reset-btn');
+    if (resetBtn) resetBtn.style.display = _chainData.exhausted.length ? '' : 'none';
+    showToast(`${provider} zurückgesetzt.`, 'ok');
+  } catch (err) {
+    showToast(`Fehler: ${err.message}`, 'error');
+  }
+}
 
 // ── Init ─────────────────────────────────────────────────────────────────────
 

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -13,7 +13,7 @@
 import 'dotenv/config';
 import { startTelegram, sendToTelegram, downloadTelegramFile } from './telegram.js';
 import { startDiscord,  sendToDiscord  }                       from './discord.js';
-import { getPairByTelegramId, getPairByDiscordId }             from './store.js';
+import { getPairByTelegramId, getPairByDiscordId, getTranslationChain } from './store.js';
 import { maybeTranslate }                                       from './translation.js';
 import { downloadUrl, classifyMime, DISCORD_MAX_BYTES, TELEGRAM_MAX_BYTES } from './media.js';
 import { startWeb }                                             from './web.js';
@@ -59,7 +59,7 @@ async function onTelegramMessage({ chatId, senderName, avatarUrl, text, media })
   // ── Text-only ──────────────────────────────────────────────────────────────
   if (!media) {
     if (!text) return;
-    const translated = await maybeTranslate(text, pair.translation, 'tgToDiscord');
+    const translated = await maybeTranslate(text, pair.translation, 'tgToDiscord', getTranslationChain());
     console.log(`[bridge] TG→DC | pair=${pair.id} | text | from="${senderName}"`);
     await sendToDiscord(pair.discordWebhookUrl, senderName, avatarUrl, translated);
     return;
@@ -110,7 +110,7 @@ async function onTelegramMessage({ chatId, senderName, avatarUrl, text, media })
     }
 
     const captionRaw = media.caption || text || null;
-    const caption    = captionRaw ? await maybeTranslate(captionRaw, pair.translation, 'tgToDiscord') : null;
+    const caption    = captionRaw ? await maybeTranslate(captionRaw, pair.translation, 'tgToDiscord', getTranslationChain()) : null;
 
     console.log(`[bridge] TG→DC | pair=${pair.id} | type=${media.type} | from="${senderName}"`);
     await sendToDiscord(pair.discordWebhookUrl, senderName, avatarUrl, caption, {
@@ -137,7 +137,7 @@ async function onDiscordMessage({ channelId, senderName, avatarUrl: _av, text, a
     : senderName;
 
   const translatedText = text
-    ? await maybeTranslate(text, pair.translation, 'discordToTg')
+    ? await maybeTranslate(text, pair.translation, 'discordToTg', getTranslationChain())
     : null;
 
   // ── Text-only ──────────────────────────────────────────────────────────────

--- a/src/store.js
+++ b/src/store.js
@@ -66,6 +66,22 @@ export function removePair(id) {
   return config.pairs.length < before;
 }
 
+// ── Translation fallback chain ────────────────────────────────────────────────
+
+/**
+ * Returns the ordered list of providers to try for translation.
+ * An empty array means "use only the pair's primary provider, no fallback".
+ */
+export function getTranslationChain() {
+  return read().translationChain ?? [];
+}
+
+export function setTranslationChain(chain) {
+  const config = read();
+  config.translationChain = chain;
+  write(config);
+}
+
 /**
  * Default translation config applied to every new pair.
  * Translation is OFF by default; the user explicitly enables it per pair.

--- a/src/translation.js
+++ b/src/translation.js
@@ -248,27 +248,57 @@ const PROVIDERS = {
   microsoft:      translateMicrosoft
 };
 
-/**
- * Translate text to targetLanguage using the given provider.
- * Returns original text on failure.
- *
- * @param {string} text
- * @param {string} targetLanguage  e.g. "English", "German"
- * @param {string} provider
- * @returns {Promise<string>}
- */
-export async function translate(text, targetLanguage, provider = 'anthropic') {
-  if (!text?.trim()) return text;
+// ── Exhaustion tracking ───────────────────────────────────────────────────────
+// Providers that have hit their quota are stored here in-memory.
+// They are skipped for all subsequent translations until manually reset.
 
-  const fn = PROVIDERS[provider];
-  if (!fn) {
-    console.warn(`[translation] Unknown provider "${provider}", skipping.`);
-    return text;
+const exhaustedProviders = new Set();
+
+export function getExhaustedProviders() {
+  return [...exhaustedProviders];
+}
+
+export function resetExhausted(provider) {
+  if (provider) {
+    exhaustedProviders.delete(provider);
+    console.log(`[translation] Exhaustion reset for: ${provider}`);
+  } else {
+    exhaustedProviders.clear();
+    console.log('[translation] Exhaustion reset for all providers');
   }
+}
 
+/**
+ * Returns true if the error signals a permanent quota/character-limit exhaustion
+ * (as opposed to a transient network or auth error).
+ */
+function isQuotaError(err) {
+  const msg = (err.message || '').toLowerCase();
+  return (
+    msg.includes(' 456:')             ||  // DeepL character quota exceeded
+    msg.includes('quota')             ||
+    msg.includes('limit exceeded')    ||
+    msg.includes('character limit')   ||
+    msg.includes('insufficient_quota')||
+    msg.includes('insufficient quota')||
+    msg.match(/ 429:/) !== null           // rate-limit → treat as quota
+  );
+}
+
+// ── Internal: single provider, throws on any error ───────────────────────────
+
+async function translateProvider(text, targetLanguage, provider) {
+  if (!text?.trim()) return text;
+  const fn = PROVIDERS[provider];
+  if (!fn) throw new Error(`Unknown provider: ${provider}`);
+  return (await fn(text, targetLanguage)) || text;
+}
+
+// ── Public: single provider with catch (backward compat) ─────────────────────
+
+export async function translate(text, targetLanguage, provider = 'anthropic') {
   try {
-    const result = await fn(text, targetLanguage);
-    return result || text;
+    return await translateProvider(text, targetLanguage, provider);
   } catch (err) {
     console.error(`[translation] ${provider} error: ${err.message}`);
     return text;
@@ -276,25 +306,58 @@ export async function translate(text, targetLanguage, provider = 'anthropic') {
 }
 
 /**
- * Apply translation based on a pair's translation config.
+ * Apply translation with automatic fallback chain.
  *
- * @param {string} text
- * @param {object} translationConfig  pair.translation
+ * Tries the pair's primary provider first, then each provider in fallbackChain
+ * in order.  When a provider returns a quota/limit error it is marked exhausted
+ * and skipped for all future calls until resetExhausted() is called.
+ * The special value 'none' in the chain means "stop and return original text".
+ *
+ * @param {string}   text
+ * @param {object}   translationConfig  pair.translation
  * @param {'tgToDiscord'|'discordToTg'} direction
+ * @param {string[]} fallbackChain  ordered list from store.getTranslationChain()
  * @returns {Promise<string>}
  */
-export async function maybeTranslate(text, translationConfig, direction) {
+export async function maybeTranslate(text, translationConfig, direction, fallbackChain = []) {
   if (process.env.TRANSLATION_ENABLED === 'false') return text;
   if (!translationConfig?.enabled) return text;
 
   const dir = translationConfig[direction];
   if (!dir?.enabled) return text;
 
-  return translate(
-    text,
-    dir.targetLanguage || 'English',
-    translationConfig.provider || 'anthropic'
-  );
+  const targetLanguage  = dir.targetLanguage || 'English';
+  const primaryProvider = translationConfig.provider || 'anthropic';
+
+  // Build deduplicated chain: primary first, then fallbacks
+  const seen  = new Set();
+  const chain = [];
+  for (const p of [primaryProvider, ...fallbackChain]) {
+    if (!seen.has(p)) { seen.add(p); chain.push(p); }
+  }
+
+  for (const provider of chain) {
+    if (provider === 'none') return text; // explicit pass-through entry
+
+    if (exhaustedProviders.has(provider)) {
+      console.log(`[translation] Skipping exhausted provider: ${provider}`);
+      continue;
+    }
+
+    try {
+      return await translateProvider(text, targetLanguage, provider);
+    } catch (err) {
+      if (isQuotaError(err)) {
+        exhaustedProviders.add(provider);
+        console.warn(`[translation] ${provider} quota reached — switching to next provider`);
+        continue;
+      }
+      console.error(`[translation] ${provider} error: ${err.message}`);
+      continue; // non-quota errors also try next provider
+    }
+  }
+
+  return text; // all providers exhausted or chain ended
 }
 
 /**

--- a/src/web.js
+++ b/src/web.js
@@ -3,8 +3,8 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
 import { v4 as uuidv4 } from 'uuid';
-import { getPairs, addPair, removePair, updatePair, DEFAULT_TRANSLATION, DEFAULT_MEDIA_SYNC } from './store.js';
-import { getProviderStatus } from './translation.js';
+import { getPairs, addPair, removePair, updatePair, DEFAULT_TRANSLATION, DEFAULT_MEDIA_SYNC, getTranslationChain, setTranslationChain } from './store.js';
+import { getProviderStatus, getExhaustedProviders, resetExhausted } from './translation.js';
 import { bot } from './telegram.js';
 import { getGuildRoles } from './discord.js';
 
@@ -342,12 +342,56 @@ export function startWeb() {
     res.json({ ok: true, displayRoles: roleIds });
   });
 
+  // ── GET /api/translation-chain ───────────────────────────────────────────
+  // Returns the current fallback chain and exhaustion state per provider.
+  app.get('/api/translation-chain', (_req, res) => {
+    res.json({
+      chain:     getTranslationChain(),
+      exhausted: getExhaustedProviders()
+    });
+  });
+
+  // ── POST /api/translation-chain ──────────────────────────────────────────
+  // Replace the fallback chain. Body: { chain: ["deepl", "google", "none"] }
+  app.post('/api/translation-chain', (req, res) => {
+    const { chain } = req.body;
+    if (!Array.isArray(chain)) {
+      return res.status(400).json({ error: 'chain must be an array.' });
+    }
+    const VALID = new Set(['anthropic','openai','ollama','google','deepl','libretranslate','microsoft','none']);
+    const invalid = chain.filter(p => !VALID.has(p));
+    if (invalid.length) {
+      return res.status(400).json({ error: `Unknown providers: ${invalid.join(', ')}` });
+    }
+    setTranslationChain(chain);
+    console.log(`[web] Translation chain updated: [${chain.join(', ')}]`);
+    res.json({ ok: true, chain });
+  });
+
+  // ── DELETE /api/translation-chain/exhausted ──────────────────────────────
+  // Reset all exhausted providers.
+  app.delete('/api/translation-chain/exhausted', (_req, res) => {
+    resetExhausted();
+    console.log('[web] All exhausted providers reset');
+    res.json({ ok: true });
+  });
+
+  // ── DELETE /api/translation-chain/exhausted/:provider ───────────────────
+  // Reset a single exhausted provider.
+  app.delete('/api/translation-chain/exhausted/:provider', (req, res) => {
+    resetExhausted(req.params.provider);
+    console.log(`[web] Exhausted provider reset: ${req.params.provider}`);
+    res.json({ ok: true, provider: req.params.provider });
+  });
+
   // ── GET /api/status ───────────────────────────────────────────────────────
   app.get('/api/status', (_req, res) => {
     res.json({
       uptime:               process.uptime(),
       pairs:                getPairs().length,
-      translationProviders: getProviderStatus()
+      translationProviders: getProviderStatus(),
+      translationChain:     getTranslationChain(),
+      exhaustedProviders:   getExhaustedProviders()
     });
   });
 


### PR DESCRIPTION
- store.js: persist fallback chain in data/config.json
- translation.js: in-memory exhausted-provider Set; isQuotaError(); getExhaustedProviders()/resetExhausted(); maybeTranslate() now walks a deduplicated chain, marks providers exhausted on quota errors, and treats 'none' as an explicit pass-through stop
- bridge.js: pass getTranslationChain() to every maybeTranslate() call
- web.js: GET/POST /api/translation-chain; DELETE exhausted (all or one); /api/status now includes chain + exhausted state
- index.html: "Translation Fallback-Kette" section in Settings with ordered list, ▲/▼ reorder, per-entry status (bereit/kein Key/erschöpft), per-entry and global reset buttons; auto-loads when Settings opens

https://claude.ai/code/session_01ULHaa8f6YnqQW1R7d3SNKz