### PR TITLE
fix: update process.env immediately when saving config via web UI

### DIFF
--- a/src/web.js
+++ b/src/web.js
@@ -422,6 +422,10 @@ export function startWeb() {
     }
     try {
       writeEnvVars(updates);
+      // Also update process.env so changes take effect without a restart
+      for (const [k, v] of Object.entries(updates)) {
+        process.env[k] = v;
+      }
       console.log(`[web] Config updated: ${Object.keys(updates).join(', ')}`);
       res.json({ ok: true, updated: Object.keys(updates) });
     } catch (err) {


### PR DESCRIPTION
When the user saves MICROSOFT_TRANSLATOR_KEY (or any other key) through the settings panel, the value was written to .env but process.env was never updated. The running process kept reading the old (empty) value, causing 'MICROSOFT_TRANSLATOR_KEY not set' errors until the service was restarted manually.

Now we mirror every written key into process.env right after the file write so the new credentials are active immediately.

https://claude.ai/code/session_0113sPWky3iTfaJj1syZsToG