### PR TITLE
fix: forward messages when selected translator is down or unresponsive

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -30,6 +30,20 @@ import { store, tgToDc, dcToTg, removeByDc }                                    
 import { downloadUrl, classifyMime, DISCORD_MAX_BYTES, TELEGRAM_MAX_BYTES } from './media.js';
 import { startWeb }                                                  from './web.js';
 
+// ── Safe translation wrapper ──────────────────────────────────────────────────
+// Guarantees a string is always returned even if maybeTranslate throws
+// unexpectedly (e.g. file-system errors in getTranslationChain).
+// This means a translator being down can never silently drop a message.
+
+async function safeTranslate(text, translationConfig, direction) {
+  try {
+    return await maybeTranslate(text, translationConfig, direction, getTranslationChain());
+  } catch (err) {
+    console.error(`[bridge] Translation threw unexpectedly, forwarding original text: ${err.message}`);
+    return text;
+  }
+}
+
 // ── mediaSync helpers ─────────────────────────────────────────────────────────
 
 const TG_TYPE_KEY = {
@@ -72,7 +86,7 @@ async function onTelegramMessage({ chatId, msgId, senderName, avatarUrl, text, m
   // ── Text-only ──────────────────────────────────────────────────────────────
   if (!media) {
     if (!text) return;
-    const translated = await maybeTranslate(text, pair.translation, 'tgToDiscord', getTranslationChain());
+    const translated = await safeTranslate(text, pair.translation, 'tgToDiscord');
     console.log(`[bridge] TG→DC | pair=${pair.id} | text | from="${senderName}"${dcReplyId ? ' (reply)' : ''}`);
     const dcMsgId = await sendToDiscord(pair.discordWebhookUrl, senderName, avatarUrl, translated, null,
       dcReplyId ? { replyToMsgId: dcReplyId, channelId: pair.discordChannelId } : {});
@@ -127,7 +141,7 @@ async function onTelegramMessage({ chatId, msgId, senderName, avatarUrl, text, m
     }
 
     const captionRaw = media.caption || text || null;
-    const caption    = captionRaw ? await maybeTranslate(captionRaw, pair.translation, 'tgToDiscord', getTranslationChain()) : null;
+    const caption    = captionRaw ? await safeTranslate(captionRaw, pair.translation, 'tgToDiscord') : null;
 
     console.log(`[bridge] TG→DC | pair=${pair.id} | type=${media.type} | from="${senderName}"${dcReplyId ? ' (reply)' : ''}`);
     const dcMsgId = await sendToDiscord(pair.discordWebhookUrl, senderName, avatarUrl, caption,
@@ -159,7 +173,7 @@ async function onDiscordMessage({ channelId, msgId, senderName, avatarUrl: _av, 
   if (pair.telegramTopicId) sendOpts.topicId    = pair.telegramTopicId;
 
   const translatedText = text
-    ? await maybeTranslate(text, pair.translation, 'discordToTg', getTranslationChain())
+    ? await safeTranslate(text, pair.translation, 'discordToTg')
     : null;
 
   // ── Text-only ──────────────────────────────────────────────────────────────

--- a/src/translation.js
+++ b/src/translation.js
@@ -296,11 +296,30 @@ function isQuotaError(err) {
 
 // ── Internal: single provider, throws on any error ───────────────────────────
 
+// Per-call timeout in ms. If the provider does not respond within this window
+// the call throws a timeout error, which maybeTranslate treats as a
+// non-quota error and falls through to the next provider (or returns original
+// text).  Configurable via TRANSLATION_TIMEOUT_MS env var.
+const TRANSLATION_TIMEOUT_MS = parseInt(process.env.TRANSLATION_TIMEOUT_MS || '15000', 10);
+
 async function translateProvider(text, targetLanguage, provider) {
   if (!text?.trim()) return text;
   const fn = PROVIDERS[provider];
   if (!fn) throw new Error(`Unknown provider: ${provider}`);
-  return (await fn(text, targetLanguage)) || text;
+
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`${provider} timed out after ${TRANSLATION_TIMEOUT_MS}ms`)),
+      TRANSLATION_TIMEOUT_MS
+    );
+  });
+
+  try {
+    return (await Promise.race([fn(text, targetLanguage), timeoutPromise])) || text;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 // ── Public: single provider with catch (backward compat) ─────────────────────


### PR DESCRIPTION
When a translation provider hangs (accepts the TCP connection but never responds), the message handler blocked indefinitely — the Anthropic SDK has a 600s default timeout, and node-fetch has none at all — so the bridged message was never forwarded.

Two-layer fix:
1. translateProvider now races each provider call against a 15-second timeout (TRANSLATION_TIMEOUT_MS env var).  A timeout is treated as a non-quota error by maybeTranslate, which logs it, skips to the next provider in the chain, and ultimately falls back to the original text.
2. A safeTranslate() wrapper in bridge.js catches any unexpected exception from maybeTranslate (e.g. file-system errors in getTranslationChain) and returns the original text, guaranteeing the message is always forwarded.

https://claude.ai/code/session_01FbU4bg1vmGnJKzJShex3NR